### PR TITLE
Check AqIndex status before retrieving value

### DIFF
--- a/gios/__init__.py
+++ b/gios/__init__.py
@@ -143,10 +143,12 @@ class Gios:
             ):
                 sensor_data[ATTR_INDEX] = STATE_MAP[index_value]
 
-        if index_value := indexes.get("AqIndex", {}).get("Nazwa kategorii indeksu"):
+        if (aq_index := indexes.get("AqIndex", {})).get(
+            "Status indeksu ogólnego dla stacji pomiarowej"
+        ):
             data[ATTR_AQI.lower()] = {
                 ATTR_NAME: ATTR_AQI,
-                ATTR_VALUE: STATE_MAP[index_value],
+                ATTR_VALUE: STATE_MAP[aq_index.get("Nazwa kategorii indeksu")],
             }
 
         if data.get("pm2.5"):


### PR DESCRIPTION
When station's index is not available, `Nazwa kategorii indeksu` is set to `Brak indeksu`.
When`Status indeksu ogólnego dla stacji pomiarowej` is not true, we should not set sensor value.

Related error:
```
2025-07-14 21:03:18.838 ERROR (MainThread) [homeassistant.components.gios.coordinator] Unexpected error fetching gios data
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 382, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/gios/coordinator.py", line 58, in _async_update_data
    return await self.gios.async_update()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/gios/__init__.py", line 149, in async_update
    ATTR_VALUE: STATE_MAP[index_value],
                ~~~~~~~~~^^^^^^^^^^^^^
KeyError: 'Brak indeksu'
```