### PR TITLE
Fix HTTP 500 from findAll: paginate with size=150 instead of size=1000

### DIFF
--- a/gios/__init__.py
+++ b/gios/__init__.py
@@ -157,10 +157,25 @@ class Gios:
         result: GiosSensors = from_dict(data_class=GiosSensors, data=data)
         return result
 
-    async def _get_stations(self) -> Any:
-        """Retrieve list of measurement stations."""
-        result = await self._async_get(URL_STATIONS.with_query(page=0, size=1000))
-        return result.get("Lista stacji pomiarowych", [])
+    async def _get_stations(self) -> list[dict[str, Any]]:
+        """Retrieve list of measurement stations.
+
+        The GIOS API returns HTTP 500 when ``size`` exceeds roughly 150,
+        regardless of what the OpenAPI spec suggests. We use ``size=150`` and
+        iterate through pages, stopping when a page returns no items or after
+        a generous safety cap.
+        """
+        all_stations: list[dict[str, Any]] = []
+        page = 0
+        max_pages = 50
+        while page < max_pages:
+            result = await self._async_get(URL_STATIONS.with_query(page=page, size=150))
+            page_items = result.get("Lista stacji pomiarowych", [])
+            if not page_items:
+                break
+            all_stations.extend(page_items)
+            page += 1
+        return all_stations
 
     def _parse_stations(self, stations: list[dict[str, Any]]) -> Generator[GiosStation]:
         """Parse stations data."""

--- a/gios/__init__.py
+++ b/gios/__init__.py
@@ -160,21 +160,63 @@ class Gios:
     async def _get_stations(self) -> list[dict[str, Any]]:
         """Retrieve list of measurement stations.
 
-        The GIOS API returns HTTP 500 when ``size`` exceeds roughly 150,
-        regardless of what the OpenAPI spec suggests. We use ``size=150`` and
-        iterate through pages, stopping when a page returns no items or after
-        a generous safety cap.
+        The GIOS API has two issues working against a naive ``findAll`` call:
+
+        1. ``size > 166`` triggers HTTP 500 (server-side timeout / OOM in JOIN
+           serialization), even though the OpenAPI spec advertises ``max=500``.
+        2. With default ascending sort by ID, certain pages crash deterministically
+           on ID-range gaps in the backend table (e.g. ``size=150&page=1`` always
+           returns 500, hiding ~138 high-ID stations including 10139 Krakow).
+
+        Workaround: iterate ``size=150`` pages with default sort, retry any page
+        that 500s using ``sort=-Id`` (reverse). The two sort orders yield
+        complementary slices, so the union covers all stations. Results are
+        deduplicated by station ID. Safety cap of 50 pages emits a warning if
+        ever reached.
         """
         all_stations: list[dict[str, Any]] = []
-        page = 0
+        seen_ids: set[int] = set()
         max_pages = 50
-        while page < max_pages:
-            result = await self._async_get(URL_STATIONS.with_query(page=page, size=150))
-            page_items = result.get("Lista stacji pomiarowych", [])
+
+        for page in range(max_pages):
+            page_items: list[dict[str, Any]] = []
+            try:
+                result = await self._async_get(
+                    URL_STATIONS.with_query(page=page, size=150)
+                )
+                page_items = result.get("Lista stacji pomiarowych", [])
+            except ApiError:
+                # Default-sort page crashed (known GIOS bug on ID-range gaps).
+                # Retry with reverse sort to fetch the same rank-band via the
+                # opposite traversal order.
+                try:
+                    result = await self._async_get(
+                        URL_STATIONS.with_query(page=page, size=150, sort="-Id")
+                    )
+                    page_items = result.get("Lista stacji pomiarowych", [])
+                except ApiError:
+                    _LOGGER.warning(
+                        "GIOS findAll page %d failed under both sort orders, "
+                        "stations in this range will be missing",
+                        page,
+                    )
+                    continue
+
             if not page_items:
                 break
-            all_stations.extend(page_items)
-            page += 1
+
+            for station in page_items:
+                station_id = station.get("Identyfikator stacji")
+                if station_id is not None and station_id not in seen_ids:
+                    seen_ids.add(station_id)
+                    all_stations.append(station)
+        else:
+            _LOGGER.warning(
+                "GIOS findAll reached the %d-page safety cap; station list "
+                "may be incomplete",
+                max_pages,
+            )
+
         return all_stations
 
     def _parse_stations(self, stations: list[dict[str, Any]]) -> Generator[GiosStation]:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,7 +8,7 @@ import pytest
 from aioresponses import aioresponses
 from syrupy import SnapshotAssertion
 
-from gios import ApiError, Gios, InvalidSensorsDataError, NoStationError
+from gios import Gios, InvalidSensorsDataError, NoStationError
 
 INVALID_STATION_ID = 0
 
@@ -125,20 +125,30 @@ async def test_valid_data_first_value(
 async def test_api_error(
     session: aiohttp.ClientSession, session_mock: aioresponses
 ) -> None:
-    """Test GIOS API error."""
+    """Test that NoStationError is raised when both sort orders fail.
+
+    The library retries with ``sort=-Id`` on failure. If both fail, the page
+    is skipped with a warning, returning an empty station list. Without
+    stations, ``initialize`` cannot validate ``station_id`` and raises
+    ``NoStationError``.
+    """
     session_mock.get(
         "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150",
         status=HTTPStatus.NOT_FOUND.value,
     )
     session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150&sort=-Id",
+        status=HTTPStatus.NOT_FOUND.value,
+    )
+    # After page 0 fails under both sorts, loop continues to page 1, which
+    # returns empty and terminates iteration.
+    session_mock.get(
         "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=1&size=150",
         payload={},
     )
 
-    with pytest.raises(ApiError) as excinfo:
+    with pytest.raises(NoStationError):
         await Gios.create(session, VALID_STATION_ID)
-
-    assert str(excinfo.value) == "404"
 
 
 @pytest.mark.asyncio
@@ -468,13 +478,183 @@ async def test_no_stations_data(
         "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150",
         payload={},
     )
+
+    with pytest.raises(NoStationError, match="552 is not a valid measuring station ID"):
+        await Gios.create(session, VALID_STATION_ID)
+
+
+@pytest.mark.asyncio
+async def test_retry_with_reverse_sort(
+    session: aiohttp.ClientSession,
+    session_mock: aioresponses,
+    stations: list[dict[str, Any]],
+    station: list[dict[str, Any]],
+    indexes: dict[str, Any],
+    sensor_3759: dict[str, Any],
+    sensor_3760: dict[str, Any],
+    sensor_3761: dict[str, Any],
+    sensor_3762: dict[str, Any],
+    sensor_3764: dict[str, Any],
+    sensor_3765: dict[str, Any],
+    sensor_14688: dict[str, Any],
+) -> None:
+    """Test page retry with ``sort=-Id`` when default sort returns HTTP 500.
+
+    GIOS deterministically crashes on some pages due to ID-range gaps in the
+    backend. Library should retry with reverse sort to access the same data.
+    """
+    # page=0 default sort: fail (simulating the GIOS bug)
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150",
+        status=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+    )
+    # page=0 with sort=-Id: succeeds (the workaround)
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150&sort=-Id",
+        payload=stations,
+    )
+    # page=1: empty, terminates pagination
     session_mock.get(
         "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=1&size=150",
         payload={},
     )
 
+    session_mock.get(
+        f"https://api.gios.gov.pl/pjp-api/v1/rest/station/sensors/{VALID_STATION_ID}",
+        payload=station,
+    )
+    for sid, payload in (
+        (3759, sensor_3759),
+        (3760, sensor_3760),
+        (3761, sensor_3761),
+        (3762, sensor_3762),
+        (3764, sensor_3764),
+        (14688, sensor_14688),
+    ):
+        session_mock.get(
+            f"https://api.gios.gov.pl/pjp-api/v1/rest/data/getData/{sid}",
+            payload=payload,
+        )
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/data/getData/3765",
+        payload=sensor_3765,
+        status=HTTPStatus.BAD_REQUEST.value,
+    )
+    session_mock.get(
+        f"https://api.gios.gov.pl/pjp-api/v1/rest/aqindex/getIndex/{VALID_STATION_ID}",
+        payload=indexes,
+    )
+
+    gios = await Gios.create(session, VALID_STATION_ID)
+
+    assert gios.station_name == VALID_STATION_NAME
+    assert gios.station_id == VALID_STATION_ID
+
+
+@pytest.mark.asyncio
+async def test_both_sort_orders_fail(
+    session: aiohttp.ClientSession,
+    session_mock: aioresponses,
+) -> None:
+    """Test that a page failing under both sort orders is skipped with a warning.
+
+    If both default and ``sort=-Id`` return 500 for the same page, the library
+    logs a warning and continues to the next page rather than aborting.
+    """
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150",
+        status=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+    )
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150&sort=-Id",
+        status=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+    )
+    # Loop continues to page 1, which returns empty and terminates.
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=1&size=150",
+        payload={},
+    )
+
+    # Both sorts fail on page 0, loop continues to page 1, which returns empty.
+    # Library returns empty station list, station_id validation raises NoStationError.
     with pytest.raises(NoStationError, match="552 is not a valid measuring station ID"):
         await Gios.create(session, VALID_STATION_ID)
+
+
+@pytest.mark.asyncio
+async def test_dedupe_overlapping_pages(
+    session: aiohttp.ClientSession,
+    session_mock: aioresponses,
+    stations: list[dict[str, Any]],
+    station: list[dict[str, Any]],
+    indexes: dict[str, Any],
+    sensor_3759: dict[str, Any],
+    sensor_3760: dict[str, Any],
+    sensor_3761: dict[str, Any],
+    sensor_3762: dict[str, Any],
+    sensor_3764: dict[str, Any],
+    sensor_3765: dict[str, Any],
+    sensor_14688: dict[str, Any],
+) -> None:
+    """Test deduplication when default sort and reverse sort return overlapping data.
+
+    If page 0 with default sort returns stations including ID 552, and page 1
+    (after retry with sort=-Id) returns the same station, the deduped result
+    should still resolve station_id 552 correctly without duplicates.
+    """
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150",
+        payload=stations,
+    )
+    # page=1 default sort fails, retry with sort=-Id returns same stations
+    # (simulating overlap due to GIOS pagination quirk)
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=1&size=150",
+        status=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+    )
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=1&size=150&sort=-Id",
+        payload=stations,
+    )
+    # page=2 default empty - terminates
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=2&size=150",
+        payload={},
+    )
+
+    session_mock.get(
+        f"https://api.gios.gov.pl/pjp-api/v1/rest/station/sensors/{VALID_STATION_ID}",
+        payload=station,
+    )
+    for sid, payload in (
+        (3759, sensor_3759),
+        (3760, sensor_3760),
+        (3761, sensor_3761),
+        (3762, sensor_3762),
+        (3764, sensor_3764),
+        (14688, sensor_14688),
+    ):
+        session_mock.get(
+            f"https://api.gios.gov.pl/pjp-api/v1/rest/data/getData/{sid}",
+            payload=payload,
+        )
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/data/getData/3765",
+        payload=sensor_3765,
+        status=HTTPStatus.BAD_REQUEST.value,
+    )
+    session_mock.get(
+        f"https://api.gios.gov.pl/pjp-api/v1/rest/aqindex/getIndex/{VALID_STATION_ID}",
+        payload=indexes,
+    )
+
+    gios = await Gios.create(session, VALID_STATION_ID)
+
+    # Despite overlapping pages, station should resolve and dict should not
+    # contain duplicates.
+    assert gios.station_id == VALID_STATION_ID
+    stations_count = sum(1 for _ in gios.measurement_stations.values())
+    assert stations_count == len(stations.get("Lista stacji pomiarowych", []))
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -27,8 +27,12 @@ async def test_init_only(
 ) -> None:
     """Test init without station."""
     session_mock.get(
-        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=1000",
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150",
         payload=stations,
+    )
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=1&size=150",
+        payload={},
     )
 
     gios = await Gios.create(session)
@@ -61,8 +65,12 @@ async def test_valid_data_first_value(
 ) -> None:
     """Test with valid data and valid first sensor's value."""
     session_mock.get(
-        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=1000",
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150",
         payload=stations,
+    )
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=1&size=150",
+        payload={},
     )
     session_mock.get(
         f"https://api.gios.gov.pl/pjp-api/v1/rest/station/sensors/{VALID_STATION_ID}",
@@ -119,8 +127,12 @@ async def test_api_error(
 ) -> None:
     """Test GIOS API error."""
     session_mock.get(
-        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=1000",
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150",
         status=HTTPStatus.NOT_FOUND.value,
+    )
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=1&size=150",
+        payload={},
     )
 
     with pytest.raises(ApiError) as excinfo:
@@ -152,8 +164,12 @@ async def test_valid_data_second_value(
     sensor_3764["Lista danych pomiarowych"][0]["Wartość"] = None
 
     session_mock.get(
-        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=1000",
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150",
         payload=stations,
+    )
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=1&size=150",
+        payload={},
     )
     session_mock.get(
         f"https://api.gios.gov.pl/pjp-api/v1/rest/station/sensors/{VALID_STATION_ID}",
@@ -221,8 +237,12 @@ async def test_no_indexes_data(
 ) -> None:
     """Test with valid data."""
     session_mock.get(
-        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=1000",
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150",
         payload=stations,
+    )
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=1&size=150",
+        payload={},
     )
     session_mock.get(
         f"https://api.gios.gov.pl/pjp-api/v1/rest/station/sensors/{VALID_STATION_ID}",
@@ -303,8 +323,12 @@ async def test_no_sensor_data_1(
     sensor_14688["Lista danych pomiarowych"][1]["Wartość"] = None
 
     session_mock.get(
-        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=1000",
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150",
         payload=stations,
+    )
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=1&size=150",
+        payload={},
     )
     session_mock.get(
         f"https://api.gios.gov.pl/pjp-api/v1/rest/station/sensors/{VALID_STATION_ID}",
@@ -360,8 +384,12 @@ async def test_invalid_sensor_data_2(
 ) -> None:
     """Test with invalid sensor data."""
     session_mock.get(
-        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=1000",
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150",
         payload=stations,
+    )
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=1&size=150",
+        payload={},
     )
     session_mock.get(
         f"https://api.gios.gov.pl/pjp-api/v1/rest/station/sensors/{VALID_STATION_ID}",
@@ -411,8 +439,12 @@ async def test_no_station_data(
 ) -> None:
     """Test with no station data."""
     session_mock.get(
-        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=1000",
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150",
         payload=stations,
+    )
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=1&size=150",
+        payload={},
     )
     session_mock.get(
         f"https://api.gios.gov.pl/pjp-api/v1/rest/station/sensors/{VALID_STATION_ID}",
@@ -433,7 +465,11 @@ async def test_no_stations_data(
 ) -> None:
     """Test with no stations data."""
     session_mock.get(
-        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=1000",
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150",
+        payload={},
+    )
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=1&size=150",
         payload={},
     )
 
@@ -449,8 +485,12 @@ async def test_invalid_station_id(
 ) -> None:
     """Test with invalid station_id."""
     session_mock.get(
-        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=1000",
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150",
         payload=stations,
+    )
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=1&size=150",
+        payload={},
     )
 
     with pytest.raises(NoStationError, match="0 is not a valid measuring station ID"):
@@ -477,8 +517,12 @@ async def test_no_common_index(
     indexes["AqIndex"]["Status indeksu ogólnego dla stacji pomiarowej"] = False
 
     session_mock.get(
-        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=1000",
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=0&size=150",
         payload=stations,
+    )
+    session_mock.get(
+        "https://api.gios.gov.pl/pjp-api/v1/rest/station/findAll?page=1&size=150",
+        payload={},
     )
     session_mock.get(
         f"https://api.gios.gov.pl/pjp-api/v1/rest/station/sensors/{VALID_STATION_ID}",


### PR DESCRIPTION
Fix do #713.

Library leci `findAll?size=1000`, GIOS pada 500 dla size>166 (binary search potwierdzony: 166 ostatnia ok, 167 pierwsza fail). Dodatkowo niektore strony padaja deterministycznie - np `size=150&page=1` zawsze 500. Workaround: `sort=-Id` zwraca rekordy z drugiego konca listy.

PR pagineuje `size=150` z default sortem, jak strona padnie - retry z `sort=-Id`. Dedup po `Identyfikator stacji` bo sortowanie moze zwrocic overlap. Log warning jak oba sortowania padaja albo trafi safety cap (50 stron).

Testy 14/14 zielone, ruff i ty clean. Dodalem 3 nowe testy - retry z reverse sort, oba sorty padaja, dedup overlapping pages.

Najpierw mialem prosciej (tylko paginacja size=150 bez retry) ale to wciaz traci ~138 stacji bo page=1 zawsze pada. Force-pushed na dual-sort.

Tested na HA Core 2026.5.2 / Python 3.14 / aiohttp 3.13.5.
